### PR TITLE
Fix docker build; should read environment at runtime

### DIFF
--- a/fortuneservice/Dockerfile
+++ b/fortuneservice/Dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.33-slim as build
 
+ENV RUST_LOG fortune=debug
 ENV FORTUNE_PATH /usr/games/fortune
 
 COPY . /code

--- a/fortuneservice/src/main.rs
+++ b/fortuneservice/src/main.rs
@@ -69,5 +69,6 @@ pub fn main() {
         })
         .map_err(|e| eprintln!("accept error: {}", e));
 
+    info!("Starting fortuneservice: {:?}", addr);
     tokio::run(serve)
 }


### PR DESCRIPTION
It seems to me that `env!` macro reads the environment value at compile time. We need to read this value at runtime instead, so we can control it from outside the docker image.

Also fix logging for fortuneservice.