### PR TITLE
Reduce size of docker image

### DIFF
--- a/fortuneservice/Dockerfile
+++ b/fortuneservice/Dockerfile
@@ -11,6 +11,8 @@ RUN apt update && apt install -y --no-install-recommends wget fortunes fortune-m
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
       wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
       chmod +x /bin/grpc_health_probe
-
 EXPOSE 50051
-ENTRYPOINT ["/code/target/debug/fortune-server"]
+
+FROM debian:buster-slim
+COPY --from=build /code/target/debug/fortune-server /usr/local/bin/fortune-server
+ENTRYPOINT ["/usr/local/bin/fortune-server"]

--- a/frontendservice/Dockerfile
+++ b/frontendservice/Dockerfile
@@ -7,6 +7,8 @@ ENV FORTUNE_SERVICE_HOSTNAME fortuneservice
 COPY . /code
 WORKDIR /code
 RUN cargo build
-
 EXPOSE 8080
-ENTRYPOINT ["/code/target/debug/frontend-server"]
+
+FROM debian:buster-slim
+COPY --from=build /code/target/debug/frontend-server /usr/local/bin/frontend-server
+ENTRYPOINT ["/usr/local/bin/frontend-server"]


### PR DESCRIPTION
Use docker multi stage build to copy only the binary to the final docker image. Reduces the size of docker image from 1.8 Gb to 128 Mb :rocket:

Fixes #14