### PR TITLE
Default vm for github actions has necessary rust tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://rust:1.39-slim-buster
       - name: Build frontendservice
         working-directory: frontendservice
         run: cargo build
@@ -18,15 +17,13 @@ jobs:
           RUST_LOG: frontend=info
       - name: Check format frontendservice
         working-directory: frontendservice
-        run: |
-          rustup component add rustfmt
-          cargo fmt -- --check
+        run: cargo fmt -- --check
+
   build-fortune:
     name: Check fortuneservice
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://rust:1.39-slim-buster
       - name: Build fortuneservice
         working-directory: fortuneservice
         run: cargo build
@@ -35,6 +32,4 @@ jobs:
           RUST_LOG: fortune=info
       - name: Check format fortuneservice
         working-directory: fortuneservice
-        run: |
-          rustup component add rustfmt
-          cargo fmt -- --check
+        run: cargo fmt -- --check


### PR DESCRIPTION
See this [article](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#ubuntu-1804-lts) or the associated [repo](https://github.com/actions/virtual-environments). An example run is visible [here](https://github.com/caulagi/bors-test/commit/796bd2f2ec967f0c92b68d6aa6484feb51d69423/checks?check_suite_id=359424479)