### PR TITLE
Tidy use of modules for frontend

### DIFF
--- a/frontendservice/Cargo.lock
+++ b/frontendservice/Cargo.lock
@@ -244,18 +244,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "frontend-server"
 version = "0.1.0"
 dependencies = [
- "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic)",
  "tonic-build 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic)",
- "tower 0.3.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
  "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp)",
 ]
 
@@ -392,7 +387,7 @@ dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -495,8 +490,8 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -971,6 +966,7 @@ dependencies = [
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1066,6 +1062,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1291,12 +1295,13 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1305,12 +1310,12 @@ dependencies = [
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1325,7 +1330,7 @@ dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1339,7 +1344,7 @@ dependencies = [
  "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1360,14 +1365,14 @@ dependencies = [
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-balance 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-load 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-make 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1386,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-buffer 0.3.0 (git+https://github.com/tower-rs/tower)",
@@ -1395,7 +1400,7 @@ dependencies = [
  "tower-limit 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-load-shed 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-retry 0.3.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-timeout 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.3.0 (git+https://github.com/tower-rs/tower)",
 ]
@@ -1403,45 +1408,45 @@ dependencies = [
 [[package]]
 name = "tower-balance"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-discover 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load 0.3.0 (git+https://github.com/tower-rs/tower)",
  "tower-make 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-ready-cache 0.3.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-buffer"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-discover"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1452,37 +1457,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "tower-limit"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-load"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-discover 0.3.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-load-shed"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1490,60 +1495,60 @@ name = "tower-make"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-ready-cache"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-retry"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-service"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tower-timeout"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tower-util"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower#2dc9a72bea615dcbf855bdfcaf3083458d9f15a6"
+source = "git+https://github.com/tower-rs/tower#d63665515c9f69cb047e2e6c9acd8e41c9a6a782"
 dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1715,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/seanmonstar/warp#ea42ba5690c75fabf847871788a79cd58177749b"
+source = "git+https://github.com/seanmonstar/warp#3a16d83457ed734960992bb00e924a85ceebfc9b"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1732,8 +1737,8 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0 (git+https://github.com/tower-rs/tower)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2025,6 +2030,7 @@ dependencies = [
 "checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
@@ -2053,8 +2059,8 @@ dependencies = [
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bcced6bb623d4bff3739c176c415f13c418f426395c169c9c3cd9a492c715b16"
-"checksum tokio-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5795a71419535c6dcecc9b6ca95bdd3c2d6142f7e8343d7beb9923f129aa87e"
+"checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
+"checksum tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7de6c21a09bab0ce34614bb1071403ad9996db62715eb61e63be5d82f91342bc"
 "checksum tokio-rustls 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ea2ce8e6bc7ce619b4fc05761a550c8a750f6bf551f2e9b1efaec93124e13d51"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic)" = "<none>"
@@ -2070,7 +2076,7 @@ dependencies = [
 "checksum tower-make 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 "checksum tower-ready-cache 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-retry 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-service 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum tower-timeout 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.3.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4e4f59e752cb3beb5b61c6d5e11191c7946231ba84faec2902c9efdd8691c5"

--- a/frontendservice/Cargo.toml
+++ b/frontendservice/Cargo.toml
@@ -9,22 +9,14 @@ name = "frontend-server"
 path = "src/main.rs"
 
 [dependencies]
-async-stream = "0.2"
 bytes = "0.4"
-futures = { version = "0.3", default-features = false, features = ["alloc"]}
-http = "0.2"
 log = "0.4"
 pretty_env_logger = "0.3.1"
 prost = "0.5"
 tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 tonic = { git = "https://github.com/hyperium/tonic", features = ["tls"] }
-tower = { git = "https://github.com/tower-rs/tower" }
-tower-service = { git = "https://github.com/tower-rs/tower" }
 # TODO: disable default-features
 warp = { git = "https://github.com/seanmonstar/warp" }
 
 [build-dependencies]
 tonic-build = { git = "https://github.com/hyperium/tonic" }
-
-[patch.crates-io]
-tower-service = { git = "https://github.com/tower-rs/tower" }

--- a/frontendservice/src/main.rs
+++ b/frontendservice/src/main.rs
@@ -31,7 +31,8 @@ fn hostname_to_ip() -> String {
     };
     log::info!(
         "resolving fortuneservice: {}, getent_path: {}",
-        service_hostname, getent_path
+        service_hostname,
+        getent_path
     );
     let child = Command::new(getent_path)
         .args(&["hosts", service_hostname.as_str()])


### PR DESCRIPTION
* Remove modules we don't directly depend on
* Remove extern for 'importing' modules